### PR TITLE
Hello World: Remove left over commands from the template.

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,15 +29,10 @@
         "url": "https://github.com/formulahendry/vscode-github-actions.git"
     },
     "activationEvents": [
-        "onCommand:extension.sayHello"
     ],
     "main": "./out/extension",
     "contributes": {
         "commands": [
-            {
-                "command": "extension.sayHello",
-                "title": "Hello World"
-            }
         ],
         "languages": [
             {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -10,18 +10,6 @@ export function activate(context: vscode.ExtensionContext) {
     // Use the console to output diagnostic information (console.log) and errors (console.error)
     // This line of code will only be executed once when your extension is activated
     console.log('Congratulations, your extension "github-actions" is now active!');
-
-    // The command has been defined in the package.json file
-    // Now provide the implementation of the command with  registerCommand
-    // The commandId parameter must match the command field in package.json
-    let disposable = vscode.commands.registerCommand('extension.sayHello', () => {
-        // The code you place here will be executed every time your command is executed
-
-        // Display a message box to the user
-        vscode.window.showInformationMessage('Hello World!');
-    });
-
-    context.subscriptions.push(disposable);
 }
 
 // this method is called when your extension is deactivated


### PR DESCRIPTION
The extension was started with `yo code` and has a populated `Hello
World` command. This command shows up when running this extension in
prodcution which is annoying and confusing.

This PR removes this command.